### PR TITLE
Fix OTP forwarding for password reset

### DIFF
--- a/lib/screens/auth/create_new_password_screen.dart
+++ b/lib/screens/auth/create_new_password_screen.dart
@@ -4,10 +4,12 @@ import 'password_success_screen.dart';
 
 class CreateNewPasswordScreen extends StatefulWidget {
   final String? phone;
+  final String otp;
 
   const CreateNewPasswordScreen({
     super.key,
     this.phone,
+    required this.otp,
   });
 
   @override
@@ -305,6 +307,7 @@ class _CreateNewPasswordScreenState extends State<CreateNewPasswordScreen> {
     try {
       final success = await ApiService.auth.resetPassword(
         phone: widget.phone ?? '0000', // Fallback для обратной совместимости
+        otp: widget.otp,
         newPassword: _passwordController.text,
       );
 

--- a/lib/screens/auth/otp_verification_screen.dart
+++ b/lib/screens/auth/otp_verification_screen.dart
@@ -276,6 +276,7 @@ class _OtpVerificationScreenState extends State<OtpVerificationScreen> {
             MaterialPageRoute(
               builder: (context) => CreateNewPasswordScreen(
                 phone: widget.phone,
+                otp: otp,
               ),
             ),
           );

--- a/lib/services/api/apis/auth.dart
+++ b/lib/services/api/apis/auth.dart
@@ -108,6 +108,7 @@ class AuthApi {
 
   Future<bool> resetPassword({
     required String phone,
+    required String otp,
     required String newPassword,
   }) async {
     final res = await CoreApi.sendRequest(
@@ -115,7 +116,7 @@ class AuthApi {
       method: 'POST',
       body: {
         'phone': phone,
-        'otp': '0000', // фиксированный OTP
+        'otp': otp,
         'newPassword': newPassword,
       },
     );


### PR DESCRIPTION
## Summary
- send the real OTP when resetting password
- pass OTP between verification and new password screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417095c7048324ac62d97b096163f5